### PR TITLE
Optimize incremental builds and local build cache usage

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -103,6 +103,7 @@ allprojects {
 
     javadoc.destinationDir = file("build/docs/apidocs")
     javadoc.options.addStringOption('Xdoclint:none', '-quiet')
+    // Workaround frpm https://bugs.openjdk.org/browse/JDK-4973681
     javadoc.options.addStringOption('sourcepath', 'src/main/java')
 
     if (!project.name in ['picocli-examples', 'picocli-annotation-processing-tests']) {

--- a/build.gradle
+++ b/build.gradle
@@ -104,14 +104,7 @@ allprojects {
     javadoc.destinationDir = file("build/docs/apidocs")
     javadoc.options.addStringOption('Xdoclint:none', '-quiet')
     javadoc.options.addStringOption('sourcepath', 'src/main/java')
-
-    // work around https://github.com/gradle/gradle/issues/4046
-//    javadoc.dependsOn('copyJavadocDocFiles')
-//    task copyJavadocDocFiles(type: Copy) {
-//        from('src/main/java')
-//        into 'build/docs/apidocs'
-//        include '**/doc-files/*.*'
-//    }
+    
     if (!project.name in ['picocli-examples', 'picocli-annotation-processing-tests']) {
         //sourceSets.main.java.srcDirs = ['src/main/java', 'src/main/java9']
         compileJava {

--- a/build.gradle
+++ b/build.gradle
@@ -60,7 +60,7 @@ pluginManager.withPlugin('biz.aQute.bnd.builder') { // if plugin applied, execut
 allprojects {
     apply plugin: 'java'
     apply plugin: 'java-library' // to avoid https://github.com/gradle/gradle/issues/1118
-//    apply plugin: "org.beryx.jar" // for compiling module-info on Java 8
+    apply plugin: "org.beryx.jar" // for compiling module-info on Java 8
 
     if (!JavaVersion.current().isJava9Compatible()) {
         sourceCompatibility = 1.5
@@ -105,12 +105,12 @@ allprojects {
     javadoc.options.addStringOption('Xdoclint:none', '-quiet')
 
     // work around https://github.com/gradle/gradle/issues/4046
-//    javadoc.dependsOn('copyJavadocDocFiles')
-//    task copyJavadocDocFiles(type: Copy) {
-//        from('src/main/java')
-//        into 'build/docs/apidocs'
-//        include '**/doc-files/*.*'
-//    }
+    javadoc.dependsOn('copyJavadocDocFiles')
+    task copyJavadocDocFiles(type: Copy) {
+        from('src/main/java')
+        into 'build/docs/apidocs'
+        include '**/doc-files/*.*'
+    }
     if (!project.name in ['picocli-examples', 'picocli-annotation-processing-tests']) {
         //sourceSets.main.java.srcDirs = ['src/main/java', 'src/main/java9']
         compileJava {
@@ -128,13 +128,13 @@ allprojects {
             //        logger.info("classpath is " + classpath.files)
             //    }
         }
-//        moduleConfig {
-//            // copy module-info.class to META-INF/versions/9
-//            multiReleaseVersion = 9
-//            moduleInfoPath = 'src/main/java9/module-info.java'
-//            version = project.version
-//            neverCompileModuleInfo = true
-//        }
+        moduleConfig {
+            // copy module-info.class to META-INF/versions/9
+            multiReleaseVersion = 9
+            moduleInfoPath = 'src/main/java9/module-info.java'
+            version = project.version
+            neverCompileModuleInfo = true
+        }
     }
 }
 
@@ -150,13 +150,13 @@ compileJava {
 //        classpath = files()
 //    }
 }
-//moduleConfig {
-//    // copy module-info.class to META-INF/versions/9
-//    multiReleaseVersion = 9
-//    moduleInfoPath = 'src/main/java9/module-info.java'
-//    version = project.version
-//    neverCompileModuleInfo = true
-//}
+moduleConfig {
+    // copy module-info.class to META-INF/versions/9
+    multiReleaseVersion = 9
+    moduleInfoPath = 'src/main/java9/module-info.java'
+    version = project.version
+    neverCompileModuleInfo = true
+}
 jar {
     manifest {
         attributes 'Specification-Title'   : 'picocli',

--- a/build.gradle
+++ b/build.gradle
@@ -60,7 +60,7 @@ pluginManager.withPlugin('biz.aQute.bnd.builder') { // if plugin applied, execut
 allprojects {
     apply plugin: 'java'
     apply plugin: 'java-library' // to avoid https://github.com/gradle/gradle/issues/1118
-    apply plugin: "org.beryx.jar" // for compiling module-info on Java 8
+//    apply plugin: "org.beryx.jar" // for compiling module-info on Java 8
 
     if (!JavaVersion.current().isJava9Compatible()) {
         sourceCompatibility = 1.5
@@ -105,12 +105,12 @@ allprojects {
     javadoc.options.addStringOption('Xdoclint:none', '-quiet')
 
     // work around https://github.com/gradle/gradle/issues/4046
-    javadoc.dependsOn('copyJavadocDocFiles')
-    task copyJavadocDocFiles(type: Copy) {
-        from('src/main/java')
-        into 'build/docs/apidocs'
-        include '**/doc-files/*.*'
-    }
+//    javadoc.dependsOn('copyJavadocDocFiles')
+//    task copyJavadocDocFiles(type: Copy) {
+//        from('src/main/java')
+//        into 'build/docs/apidocs'
+//        include '**/doc-files/*.*'
+//    }
     if (!project.name in ['picocli-examples', 'picocli-annotation-processing-tests']) {
         //sourceSets.main.java.srcDirs = ['src/main/java', 'src/main/java9']
         compileJava {
@@ -128,13 +128,13 @@ allprojects {
             //        logger.info("classpath is " + classpath.files)
             //    }
         }
-        moduleConfig {
-            // copy module-info.class to META-INF/versions/9
-            multiReleaseVersion = 9
-            moduleInfoPath = 'src/main/java9/module-info.java'
-            version = project.version
-            neverCompileModuleInfo = true
-        }
+//        moduleConfig {
+//            // copy module-info.class to META-INF/versions/9
+//            multiReleaseVersion = 9
+//            moduleInfoPath = 'src/main/java9/module-info.java'
+//            version = project.version
+//            neverCompileModuleInfo = true
+//        }
     }
 }
 
@@ -150,13 +150,13 @@ compileJava {
 //        classpath = files()
 //    }
 }
-moduleConfig {
-    // copy module-info.class to META-INF/versions/9
-    multiReleaseVersion = 9
-    moduleInfoPath = 'src/main/java9/module-info.java'
-    version = project.version
-    neverCompileModuleInfo = true
-}
+//moduleConfig {
+//    // copy module-info.class to META-INF/versions/9
+//    multiReleaseVersion = 9
+//    moduleInfoPath = 'src/main/java9/module-info.java'
+//    version = project.version
+//    neverCompileModuleInfo = true
+//}
 jar {
     manifest {
         attributes 'Specification-Title'   : 'picocli',

--- a/build.gradle
+++ b/build.gradle
@@ -103,14 +103,15 @@ allprojects {
 
     javadoc.destinationDir = file("build/docs/apidocs")
     javadoc.options.addStringOption('Xdoclint:none', '-quiet')
+    javadoc.options.addStringOption('sourcepath', 'src/main/java')
 
     // work around https://github.com/gradle/gradle/issues/4046
-    javadoc.dependsOn('copyJavadocDocFiles')
-    task copyJavadocDocFiles(type: Copy) {
-        from('src/main/java')
-        into 'build/docs/apidocs'
-        include '**/doc-files/*.*'
-    }
+//    javadoc.dependsOn('copyJavadocDocFiles')
+//    task copyJavadocDocFiles(type: Copy) {
+//        from('src/main/java')
+//        into 'build/docs/apidocs'
+//        include '**/doc-files/*.*'
+//    }
     if (!project.name in ['picocli-examples', 'picocli-annotation-processing-tests']) {
         //sourceSets.main.java.srcDirs = ['src/main/java', 'src/main/java9']
         compileJava {

--- a/build.gradle
+++ b/build.gradle
@@ -104,7 +104,7 @@ allprojects {
     javadoc.destinationDir = file("build/docs/apidocs")
     javadoc.options.addStringOption('Xdoclint:none', '-quiet')
     javadoc.options.addStringOption('sourcepath', 'src/main/java')
-    
+
     if (!project.name in ['picocli-examples', 'picocli-annotation-processing-tests']) {
         //sourceSets.main.java.srcDirs = ['src/main/java', 'src/main/java9']
         compileJava {
@@ -160,6 +160,13 @@ jar {
                    'Implementation-Vendor' : 'Remko Popma',
                    'Implementation-Version': archiveVersion.get(),
                    'Main-Class'            : 'picocli.AutoComplete'
+    }
+}
+normalization {
+    runtimeClasspath {
+        metaInf {
+            ignoreAttribute("Bnd-LastModified")
+        }
     }
 }
 configurations {

--- a/build.gradle
+++ b/build.gradle
@@ -130,6 +130,14 @@ allprojects {
             neverCompileModuleInfo = true
         }
     }
+
+    normalization {
+        runtimeClasspath {
+            metaInf {
+                ignoreAttribute("Bnd-LastModified")
+            }
+        }
+    }
 }
 
 //sourceSets.main.java.srcDirs = ['src/main/java', 'src/main/java9']
@@ -160,13 +168,6 @@ jar {
                    'Implementation-Vendor' : 'Remko Popma',
                    'Implementation-Version': archiveVersion.get(),
                    'Main-Class'            : 'picocli.AutoComplete'
-    }
-}
-normalization {
-    runtimeClasspath {
-        metaInf {
-            ignoreAttribute("Bnd-LastModified")
-        }
     }
 }
 configurations {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.caching = false

--- a/gradle/docs.gradle
+++ b/gradle/docs.gradle
@@ -41,7 +41,7 @@ javadoc {
     }
 }
 javadoc.dependsOn(jar)
-//javadoc.dependsOn('asciidoctor')
+javadoc.dependsOn('asciidoctor')
 asciidoctorj {
     version = '2.5.5'
 }

--- a/gradle/docs.gradle
+++ b/gradle/docs.gradle
@@ -41,7 +41,7 @@ javadoc {
     }
 }
 javadoc.dependsOn(jar)
-javadoc.dependsOn('asciidoctor')
+//javadoc.dependsOn('asciidoctor')
 asciidoctorj {
     version = '2.5.5'
 }

--- a/picocli-codegen/build.gradle
+++ b/picocli-codegen/build.gradle
@@ -51,6 +51,7 @@ task generateManpageAsciiDoc(type: JavaExec) {
     description = "Generate AsciiDoc manpage"
     classpath(configurations.compileClasspath, configurations.annotationProcessor, sourceSets.main.runtimeClasspath)
     mainClass = 'picocli.codegen.docgen.manpage.ManPageGenerator'
+    outputs.dir("${project.buildDir}/picocli-generated-docs")
     args 'picocli.codegen.docgen.manpage.ManPageGenerator$App',
             'picocli.codegen.aot.graalvm.DynamicProxyConfigGenerator$App',
             'picocli.codegen.aot.graalvm.ReflectionConfigGenerator$App',

--- a/picocli-examples/build.gradle
+++ b/picocli-examples/build.gradle
@@ -60,9 +60,10 @@ sourceSets {
 //a task that generates the resources for the example VersionProviderDemo1:
 task generateVersionTxt {
     description 'Creates a version.txt file with build info that is added to the root of the picocli-examples jar'
+    def generated = new File(generatedResources, "version.txt")
+    outputs.file(generated)
     doLast {
         new File(generatedResources).mkdirs()
-        def generated = new File(generatedResources, "version.txt")
         generated.text = """
 Version: $rootProject.version
 Buildtime: ${new java.text.SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(new Date())}

--- a/picocli-examples/build.gradle
+++ b/picocli-examples/build.gradle
@@ -71,6 +71,13 @@ Application-name: $rootProject.name $project.name
 """
     }
 }
+normalization {
+    runtimeClasspath {
+        properties('**/version.txt') {
+            ignoreProperty 'Buildtime'
+        }
+    }
+}
 
 tasks.withType(Javadoc).all { enabled = false }
 //tasks.withType(Javadoc) {

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,19 +1,3 @@
-plugins {
-    id 'com.gradle.enterprise' version '3.10.3'
-    id 'com.gradle.common-custom-user-data-gradle-plugin' version '1.7.2'
-}
-gradleEnterprise {
-    server = 'https://ec2-3-236-229-34.compute-1.amazonaws.com'
-    allowUntrustedServer = true
-    buildScan {
-        publishAlways()
-        capture {
-            taskInputFiles = true 
-        }
-        uploadInBackground = System.getenv("CI") == null
-    }
-}
-
 rootProject.name = 'picocli'
 include 'picocli-groovy'
 include 'picocli-examples'

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,19 @@
+plugins {
+    id 'com.gradle.enterprise' version '3.10.3'
+    id 'com.gradle.common-custom-user-data-gradle-plugin' version '1.7.2'
+}
+gradleEnterprise {
+    server = 'https://ec2-3-236-229-34.compute-1.amazonaws.com'
+    allowUntrustedServer = true
+    buildScan {
+        publishAlways()
+        capture {
+            taskInputFiles = true 
+        }
+        uploadInBackground = System.getenv("CI") == null
+    }
+}
+
 rootProject.name = 'picocli'
 include 'picocli-groovy'
 include 'picocli-examples'
@@ -11,4 +27,3 @@ if (org.gradle.api.JavaVersion.current().isJava8Compatible()) {
 } else {
     println("Excluding module picocli-annotation-processing-tests from the build: they require Java 8 but we have Java version ${org.gradle.api.JavaVersion.current()}")
 }
-


### PR DESCRIPTION
- Optimize incremental builds
  - Replace `copyJavadocDocFiles` workaround by javadoc sourcepath
  - Specify output dir in `generateManpageAsciiDoc` task
  - Specify output file in `generateVersionTxt` task
- Optimize local build cache usage
  - Add normalization for `manifest.mf` to ignore `Bnd-LastModified` attribute
  - Add normalization for `version.txt` in 'picocli-examples` to ignore `Buildtime` property